### PR TITLE
README: remove "for Node.js", it's a universal package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ stats-lite
 
 [![NPM](https://nodei.co/npm/stats-lite.png)](https://nodei.co/npm/stats-lite/)
 
-A fairly light statistical package for Node.js. Works with numeric arrays, and will automatically filter out non-numeric values and attempt to convert string numeric values.
+A fairly light statistical package. Works with numeric arrays, and will automatically filter out non-numeric values and attempt to convert string numeric values.
 
 Example
 ---


### PR DESCRIPTION
* Remove "for Node.js" because it does not use Node.js API, so it's an universal/isomorphic package