### PR TITLE
Add sampleStdev and sampleVariance methods. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,20 @@ console.log("median: %s", stats.median(rolls))
 console.log("mode: %s", stats.mode(rolls))
 console.log("variance: %s", stats.variance(rolls))
 console.log("standard deviation: %s", stats.stdev(rolls))
+console.log("sample standard deviation: %s", stats.sampleStdev(rolls))
 console.log("85th percentile: %s", stats.percentile(rolls, 0.85))
-console.log("histogram:", stats.histogram(rolls))
+console.log("histogram:", stats.histogram(rolls, 10))
 
 /* Your exact numbers may vary, but they should be pretty similar:
-sum: 21006
-mean: 7.002
+sum: 21041
+mean: 7.0136666666666665
 median: 7
 mode: 7
-variance: 5.907329333333325
-standard deviation: 2.430499811424252
+variance: 5.8568132222220415
+standard deviation: 2.4200853749861886
+sample standard deviation: 2.4204888234135953
 85th percentile: 10
-histogram { values: [ 86, 159, 253, 335, 907, 405, 339, 270, 146, 100 ],
+histogram { values: [ 94, 163, 212, 357, 925, 406, 330, 264, 164, 85 ],
   bins: 10,
   binWidth: 1.05,
   binLimits: [ 1.75, 12.25 ] }
@@ -95,12 +97,23 @@ If `vals` is multi-modal (contains multiple modes), `mode(vals)` will return a E
 `variance(vals)`
 ---
 
-Calculate the [variance](http://en.wikipedia.org/wiki/Variance) from the mean.
+Calculate the [variance](http://en.wikipedia.org/wiki/Variance) from the mean for a population.
 
 `stdev(vals)`
 ---
 
-Calculate the [standard deviation](http://en.wikipedia.org/wiki/Standard_deviation) of the values from the mean.
+Calculate the [standard deviation](http://en.wikipedia.org/wiki/Standard_deviation) of the values from the mean for a population.
+
+`sampleVariance(vals)`
+---
+
+Calculate the [variance](http://en.wikipedia.org/wiki/Variance) from the mean for a sample.
+
+`sampleStdev(vals)`
+---
+
+Calculate the [standard deviation](http://en.wikipedia.org/wiki/Standard_deviation) of the values from the mean for a sample.
+
 
 `percentile(vals, ptile)`
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stats-lite",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A light statistical package that operates on numeric Arrays.",
   "main": "stats.js",
   "directories": {

--- a/stats.js
+++ b/stats.js
@@ -5,8 +5,12 @@ module.exports.sum = sum
 module.exports.mean = mean
 module.exports.median = median
 module.exports.mode = mode
-module.exports.variance = variance
-module.exports.stdev = stdev
+module.exports.variance = populationVariance
+module.exports.sampleVariance = sampleVariance
+module.exports.populationVariance = populationVariance
+module.exports.stdev = populationStdev
+module.exports.sampleStdev = sampleStdev
+module.exports.populationStdev = populationStdev
 module.exports.percentile = percentile
 module.exports.histogram = histogram
 
@@ -98,20 +102,41 @@ function mode(vals) {
   return mode
 }
 
-// Variance = average squared deviation from mean
-function variance(vals) {
+// This helper finds the mean of all the values, then squares the difference
+// from the mean for each value and returns the resulting array.  This is the
+// core of the varience functions - the difference being dividing by N or N-1.
+function valuesMinusMeanSquared(vals) {
   vals = numbers(vals)
   var avg = mean(vals)
   var diffs = []
   for (var i = 0; i < vals.length; i++) {
     diffs.push(Math.pow((vals[i] - avg), 2))
   }
-  return mean(diffs)
+  return diffs
 }
 
-// Standard Deviation = sqrt of variance
-function stdev(vals) {
-  return Math.sqrt(variance(vals))
+// Population Variance = average squared deviation from mean
+function populationVariance(vals) {
+  return mean(valuesMinusMeanSquared(vals))
+}
+
+// Sample Variance
+function sampleVariance(vals) {
+  var diffs = valuesMinusMeanSquared(vals)
+  if (diffs.length <= 1) return NaN
+
+  return sum(diffs) / (diffs.length - 1)
+}
+
+
+// Population Standard Deviation = sqrt of population variance
+function populationStdev(vals) {
+  return Math.sqrt(populationVariance(vals))
+}
+
+// Sample Standard Deviation = sqrt of sample variance
+function sampleStdev(vals) {
+  return Math.sqrt(sampleVariance(vals))
 }
 
 function percentile(vals, ptile) {

--- a/test/index.js
+++ b/test/index.js
@@ -106,6 +106,24 @@ test("variance", function (t) {
   t.end()
 })
 
+test("sampleVariance", function (t) {
+  var variance = stats.sampleVariance
+
+  t.equals(typeof variance, "function", "sampleVariance is a function")
+
+  t.ok(isNaN(variance()), "sampleVariance of nothing is NaN")
+
+  t.ok(isNaN(variance([])), "sampleVariance of nothing is NaN")
+
+  t.ok(isNaN(variance([42.4242])), "sampleVariance of one thing is NaN")
+
+  t.deepEquals(variance([2, 4, 4, 4, 5, 5, 7, 9]), 4.571428571428571, "sampleVariance works")
+
+  t.deepEquals(variance([600, "470", 170, 430, 300]), 27130, "sampleVariance works")
+
+  t.end()
+})
+
 test("stdev", function (t) {
   var stdev = stats.stdev
 
@@ -115,9 +133,32 @@ test("stdev", function (t) {
 
   t.ok(isNaN(stdev([])), "stdev of nothing is NaN")
 
+  t.deepEquals(stdev([42.4242]), 0, "stdev of one thing is zero")
+
   t.deepEquals(stdev([2, 4, 4, 4, 5, 5, 7, 9]), 2, "stdev works")
 
   t.deepEquals(stdev([600, "470", 170, 430, 300]), 147.32277488562318, "stdev works")
+
+  t.end()
+})
+
+
+test("sampleStdev", function (t) {
+  var stdev = stats.sampleStdev
+
+  t.equals(typeof stdev, "function", "sampleStdev is a function")
+
+  t.ok(isNaN(stdev()), "sampleStdev of nothing is NaN")
+
+  t.ok(isNaN(stdev([])), "sampleStdev of nothing is NaN")
+
+  t.ok(isNaN(stdev([42.4242])), "sampleStdev of 1 thing is NaN")
+
+  t.deepEquals(stdev([2, 4, 4, 4, 5, 5, 7, 9]), 2.138089935299395, "sampleStdev works")
+
+  t.deepEquals(stdev([600, "470", 170, 430, 300]), 164.7118696390761, "sampleStdev works")
+
+  t.deepEquals(stdev([710, 660.474666666667, 337.83, 600, 550, 710]), 140.6576424153763, "sampleStdev works")
 
   t.end()
 })


### PR DESCRIPTION
The stdev and variance functions, as exposed, continue to be population functions.

When the sample sizes are large enough, the values for sampleStdev and sampleVariance are very close. However, I was using a sample size of 6 and was seeing a large difference. Ultimately, I tracked this down to sample vs population standard deviations (and variances). This package uses stdev as a population functions where software such as postgres and applications such as google sheets use sample functions.

- Update the README with new functions
- Tests for sampleStdev and sampleVariance
- Expose 4 new functions: sampleStdev, populationStdev, sampleVariance, and populationVariance
- Alias stdev to populationStdev for compatibility
- Alias variance to populationVariance for compatibility
- Add test for populationStdev of only one thing